### PR TITLE
Scheduler Fix

### DIFF
--- a/src/main/java/extratan/core/ExtraTAN.java
+++ b/src/main/java/extratan/core/ExtraTAN.java
@@ -16,7 +16,6 @@ import extratan.lootfunctions.ApplyRandomTempProt;
 import lieutenant.core.Lieutenant;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
@@ -78,13 +77,13 @@ public class ExtraTAN {
 		// Also skip initalization if the user has disabled core functionality.
 		if (ConfigHandler.common.disableTANFeatures) return;
 		
-		GameRegistry.addSmelting(Item.getByNameOrId("extratan:filled_flask"), new ItemStack(Item.getByNameOrId("extratan:flask_with_hot_water")), 0);
-		GameRegistry.addSmelting(Item.getByNameOrId("extratan:flask_with_cold_water"), new ItemStack(Item.getByNameOrId("extratan:filled_flask")), 0);
+		GameRegistry.addSmelting(ItemList.WATER_FILLED_FLASK, new ItemStack(ItemList.HOT_DRINK), 0);
+		GameRegistry.addSmelting(ItemList.COLD_DRINK, new ItemStack(ItemList.WATER_FILLED_FLASK), 0);
 		
 		// Add the new Flint and Steel recipes if its' enabled.
 		if (ConfigHandler.common.UseFlintandSteelRecipes) {
-			GameRegistry.addShapelessRecipe(new ResourceLocation(ExtraTAN.modId+"flintsteelheat"), null, new ItemStack(Item.getByNameOrId("extratan:flask_with_hot_water")), new Ingredient[] {Ingredient.fromItem(Item.getByNameOrId("extratan:filled_flask")), Ingredient.fromItem(Items.FLINT_AND_STEEL)});
-			GameRegistry.addShapelessRecipe(new ResourceLocation(ExtraTAN.modId+"flintsteelheat2"), null, new ItemStack(Item.getByNameOrId("extratan:filled_flask")), new Ingredient[] {Ingredient.fromItem(Item.getByNameOrId("extratan:flask_with_cold_water")), Ingredient.fromItem(Items.FLINT_AND_STEEL)});
+			GameRegistry.addShapelessRecipe(new ResourceLocation(ExtraTAN.modId+"flintsteelheat"), null, new ItemStack(ItemList.HOT_DRINK), new Ingredient[] {Ingredient.fromItem(ItemList.WATER_FILLED_FLASK), Ingredient.fromItem(Items.FLINT_AND_STEEL)});
+			GameRegistry.addShapelessRecipe(new ResourceLocation(ExtraTAN.modId+"flintsteelheat2"), null, new ItemStack(ItemList.WATER_FILLED_FLASK), new Ingredient[] {Ingredient.fromItem(ItemList.COLD_DRINK), Ingredient.fromItem(Items.FLINT_AND_STEEL)});
 		}
 		
 		SyncHandler.init(); // Initialize the packet synchronizer.

--- a/src/main/java/extratan/items/BaseBreakableDrinkableItem.java
+++ b/src/main/java/extratan/items/BaseBreakableDrinkableItem.java
@@ -20,7 +20,7 @@ import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import toughasnails.api.stat.capability.ITemperature;
 
-public class BaseBreakableDrinkableItem extends BaseDrinkableItem {
+public class BaseBreakableDrinkableItem extends BaseDrinkableItem implements IConsumableThirst {
 
 	protected int tempModifier;
 	protected String name;
@@ -30,7 +30,7 @@ public class BaseBreakableDrinkableItem extends BaseDrinkableItem {
 	List<ItemStack> timedItems = new ArrayList<ItemStack>();
 	Map<ItemStack,Timer> itemTimers = new HashMap<ItemStack,Timer>();
 	
-	public BaseBreakableDrinkableItem(String name, String registryName, int temperature, BaseCreativeTab creativeTab)
+	public BaseBreakableDrinkableItem(String name, String registryName, BaseCreativeTab creativeTab)
 	{
 		super(registryName, registryName, creativeTab);
 		
@@ -99,7 +99,7 @@ public class BaseBreakableDrinkableItem extends BaseDrinkableItem {
 		EntityPlayer player = (EntityPlayer)entityIn;
 		
 		player.playSound(new SoundEvent(new ResourceLocation("minecraft:block.glass.break")), 1, 1); // Play a glass break sound.
-		player.inventory.removeStackFromSlot(itemSlot); // Delete the item.
+		player.inventory.removeStackFromSlot(player.inventory.getSlotFor(stack)); // Delete the item.
 		itemTimers.get(stack).cancel(); // Cancel the timer when done.
 		itemTimers.remove(stack); // Remove the timer.
 		timedItems.remove(timedItems.indexOf(stack)); // Removed the stack from the list.

--- a/src/main/java/extratan/items/Items/ItemList.java
+++ b/src/main/java/extratan/items/Items/ItemList.java
@@ -2,6 +2,7 @@ package extratan.items.Items;
 
 import extratan.blocks.TransparentBlockBase;
 import extratan.creativetabs.CreativeTabHandler;
+import extratan.items.BaseBreakableDrinkableItem;
 import extratan.items.BaseDrinkableItem;
 import extratan.items.BaseFlask;
 import net.minecraft.block.Block;
@@ -85,7 +86,7 @@ public class ItemList {
 		};
 	};
 	
-	public static final Item  SUPER_HOT_DRINK  = new BaseDrinkableItem("superHotDrink", "flask_with_super_hot_water", CreativeTabHandler.ExtraTANDrinks) {
+	public static final Item  SUPER_HOT_DRINK  = new BaseBreakableDrinkableItem("superHotDrink", "flask_with_super_hot_water", CreativeTabHandler.ExtraTANDrinks) {
 		public int GetTemperatureModifier() {
 			return 8;
 		};
@@ -101,7 +102,7 @@ public class ItemList {
 		};
 	};
 	
-	public static final Item  SUPER_COLD_DRINK  = new BaseDrinkableItem("superColdDrink", "flask_with_super_cold_water", CreativeTabHandler.ExtraTANDrinks) {
+	public static final Item  SUPER_COLD_DRINK  = new BaseBreakableDrinkableItem("superColdDrink", "flask_with_super_cold_water", CreativeTabHandler.ExtraTANDrinks) {
 		public int GetTemperatureModifier() {
 			return -8;
 		};


### PR DESCRIPTION
Fixes a problem where if the timer on a breakable flask is started, and then it breaks while on a different slot, the item in the original slot will break. This has to do with the fact that the slot is cached during the scheduler, and then it tries to use the cached slot instead of finding the true slot.

Additionally cleans up some loose code that wasn't using the static identifiers.

closes #7